### PR TITLE
hardware_interfaceのパラメータをxacro引数から変更する

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ source ~/ros2_ws/install/setup.bash
 ```sh
 # Connect CRANE+V2 to PC, then
 $ source ~/ros2_ws/install/setup.bash
-$ ros2 launch crane_plus_examples demo.launch.py
+$ ros2 launch crane_plus_examples demo.launch.py port_name:=/dev/ttyUSB0
 
 # Terminal 2
 $ source ~/ros2_ws/install/setup.bash

--- a/crane_plus_control/README.md
+++ b/crane_plus_control/README.md
@@ -32,15 +32,6 @@ PCとCRANE+V2の設定が必要です。
 $ sudo chmod 666 /dev/ttyUSB0
 ```
 
-### USB通信ポートの変更
-
-`/dev/ttyUBS0`以外の通信ポートを使用する場合は
-起動時の引数`port_name`を変更します。
-
-```sh
-$ ros2 launch crane_plus_examples demo.launch.py port_name:=/dev/ttyUSB0
-```
-
 ### latency_timerの設定
 
 CRANE+V2を100 Hz周期で制御するためには、
@@ -149,7 +140,13 @@ CRANE+V2の腕の制御用に`crane_plus_arm_controller`を、
 
 ### USB通信ポート
 
-[USB通信ポートの変更](#usb通信ポートの変更)を参照してください。
+`port_name`はCRANE+V2との通信に使用するUSB通信ポートを設定します。
+
+コマンド実行時の引数からも変更が可能です。
+
+```sh
+$ ros2 launch crane_plus_control crane_plus_control.launch.py port_name:=/dev/ttyUSB0
+```
 
 ### ボーレート
 

--- a/crane_plus_control/README.md
+++ b/crane_plus_control/README.md
@@ -35,15 +35,10 @@ $ sudo chmod 666 /dev/ttyUSB0
 ### USB通信ポートの変更
 
 `/dev/ttyUBS0`以外の通信ポートを使用する場合は
-[crane_plus_description/urdf/crane_plus.ros2_control.xacro](../crane_plus_description/urdf/crane_plus.ros2_control.xacro)
-の`port_name`を変更します。
+起動時の引数`port_name`を変更します。
 
-```xml
-<ros2_control name="${name}" type="system">
-  <hardware>
-    <plugin>crane_plus_hardware/CranePlusHardware</plugin>
-    <param name="port_name">/dev/ttyUSB0</param>
-    <param name="baudrate">1000000</param>
+```sh
+$ ros2 launch crane_plus_examples demo.launch.py port_name:=/dev/ttyUSB0
 ```
 
 ### latency_timerの設定
@@ -138,21 +133,18 @@ CRANE+V2の腕の制御用に`crane_plus_arm_controller`を、
 ## crane_plus_hardwareのパラメータ
 
 `crane_plus_hardware`のパラメータは
-[crane_plus_description/urdf/crane_plus.ros2_control.xacro](../crane_plus_description/urdf/crane_plus.ros2_control.xacro)
+[crane_plus_description/urdf/crane_plus.urdf.xacro](../crane_plus_description/urdf/crane_plus.urdf.xacro)
 で設定しています。
 
 ```xml
-<ros2_control name="${name}" type="system">
-  <hardware>
-    <plugin>crane_plus_hardware/CranePlusHardware</plugin>
-    <param name="port_name">/dev/ttyUSB0</param>
-    <param name="baudrate">1000000</param>
-    <param name="timeout_seconds">5.0</param>
-    <param name="read_velocities">0</param>
-    <param name="read_loads">0</param>
-    <param name="read_voltages">0</param>
-    <param name="read_temperatures">0</param>
-  </hardware>
+<xacro:arg name="use_gazebo" default="false" />
+<xacro:arg name="port_name" default="/dev/ttyUSB0" />
+<xacro:arg name="baudrate" default="1000000" />
+<xacro:arg name="timeout_seconds" default="5.0" />
+<xacro:arg name="read_velocities" default="0" />
+<xacro:arg name="read_loads" default="0" />
+<xacro:arg name="read_voltages" default="0" />
+<xacro:arg name="read_temperatures" default="0" />
 ```
 
 ### USB通信ポート
@@ -178,7 +170,7 @@ USBケーブルや電源ケーブルが抜けた場合等に有効です。
 `read_velocities`、`read_loads`、`read_voltages`、`read_temperatures`
 は、サーボの回転速度、電圧、負荷、温度を読み取るためのパラメータです。
 
-`1`をセットすると、サーボパラメータを読み取るみます。
+`1`をセットすると、サーボパラメータを読み取ります。
 
 これらのパラメータを読み取ると通信データ量が増加するため、制御周期が100 Hzより低下します。
 

--- a/crane_plus_control/launch/crane_plus_control.launch.py
+++ b/crane_plus_control/launch/crane_plus_control.launch.py
@@ -18,6 +18,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
 from launch.actions import DeclareLaunchArgument
+from launch.substitutions import Command
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 import xacro
@@ -25,8 +26,8 @@ import xacro
 
 def generate_launch_description():
     # Get URDF via xacro
-    declare_xacro_port_name = DeclareLaunchArgument(
-        'xacro_port_name',
+    declare_port_name = DeclareLaunchArgument(
+        'port_name',
         default_value='/dev/ttyUSB0',
         description='Set port name.'
     )
@@ -35,8 +36,11 @@ def generate_launch_description():
         'urdf',
         'crane_plus.urdf.xacro')
     
-    robot_description_config = xacro.process_file(robot_description_path, mappings={'port_name' : LaunchConfiguration('xacro_port_name')})
-    robot_description = {'robot_description': robot_description_config.toxml()}
+    robot_description = {'robot_description': Command(
+        ['xacro ',
+         robot_description_path,
+         ' port_name:=', LaunchConfiguration('port_name')
+        ])}
 
     crane_plus_controllers = os.path.join(
         get_package_share_directory('crane_plus_control'),
@@ -73,7 +77,7 @@ def generate_launch_description():
             )
 
     return LaunchDescription([
-      declare_xacro_port_name,
+      declare_port_name,
       controller_manager,
       spawn_joint_state_controller,
       spawn_arm_controller,

--- a/crane_plus_control/launch/crane_plus_control.launch.py
+++ b/crane_plus_control/launch/crane_plus_control.launch.py
@@ -17,17 +17,25 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 import xacro
 
 
 def generate_launch_description():
     # Get URDF via xacro
+    declare_xacro_port_name = DeclareLaunchArgument(
+        'xacro_port_name',
+        default_value='/dev/ttyUSB0',
+        description='Set port name.'
+    )
     robot_description_path = os.path.join(
         get_package_share_directory('crane_plus_description'),
         'urdf',
         'crane_plus.urdf.xacro')
-    robot_description_config = xacro.process_file(robot_description_path)
+    
+    robot_description_config = xacro.process_file(robot_description_path, mappings={'port_name' : LaunchConfiguration('xacro_port_name')})
     robot_description = {'robot_description': robot_description_config.toxml()}
 
     crane_plus_controllers = os.path.join(
@@ -65,6 +73,7 @@ def generate_launch_description():
             )
 
     return LaunchDescription([
+      declare_xacro_port_name,
       controller_manager,
       spawn_joint_state_controller,
       spawn_arm_controller,

--- a/crane_plus_control/launch/crane_plus_control.launch.py
+++ b/crane_plus_control/launch/crane_plus_control.launch.py
@@ -21,7 +21,6 @@ from launch.actions import DeclareLaunchArgument
 from launch.substitutions import Command
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-import xacro
 
 
 def generate_launch_description():
@@ -31,15 +30,16 @@ def generate_launch_description():
         default_value='/dev/ttyUSB0',
         description='Set port name.'
     )
+
     robot_description_path = os.path.join(
         get_package_share_directory('crane_plus_description'),
         'urdf',
         'crane_plus.urdf.xacro')
-    
-    robot_description = {'robot_description': Command(
-        ['xacro ',
-         robot_description_path,
-         ' port_name:=', LaunchConfiguration('port_name')
+
+    robot_description = {'robot_description': Command([
+        'xacro ',
+        robot_description_path,
+        ' port_name:=', LaunchConfiguration('port_name')
         ])}
 
     crane_plus_controllers = os.path.join(

--- a/crane_plus_description/urdf/crane_plus.ros2_control.xacro
+++ b/crane_plus_description/urdf/crane_plus.ros2_control.xacro
@@ -18,18 +18,24 @@
             joint_4_upper_limit
             joint_hand_lower_limit
             joint_hand_upper_limit
-            port_name">
+            port_name
+            baudrate
+            timeout_seconds
+            read_velocities
+            read_loads
+            read_voltages
+            read_temperatures">
 
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>crane_plus_hardware/CranePlusHardware</plugin>
         <param name="port_name">${port_name}</param>
-        <param name="baudrate">1000000</param>
-        <param name="timeout_seconds">5.0</param>
-        <param name="read_velocities">0</param>
-        <param name="read_loads">0</param>
-        <param name="read_voltages">0</param>
-        <param name="read_temperatures">0</param>
+        <param name="baudrate">${baudrate}</param>
+        <param name="timeout_seconds">${timeout_seconds}</param>
+        <param name="read_velocities">${read_velocities}</param>
+        <param name="read_loads">${read_loads}</param>
+        <param name="read_voltages">${read_voltages}</param>
+        <param name="read_temperatures">${read_temperatures}</param>
       </hardware>
 
       <joint name="${name_joint_1}">

--- a/crane_plus_description/urdf/crane_plus.ros2_control.xacro
+++ b/crane_plus_description/urdf/crane_plus.ros2_control.xacro
@@ -17,12 +17,13 @@
             joint_4_lower_limit
             joint_4_upper_limit
             joint_hand_lower_limit
-            joint_hand_upper_limit">
+            joint_hand_upper_limit
+            port_name">
 
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>crane_plus_hardware/CranePlusHardware</plugin>
-        <param name="port_name">/dev/ttyUSB0</param>
+        <param name="port_name">${port_name}</param>
         <param name="baudrate">1000000</param>
         <param name="timeout_seconds">5.0</param>
         <param name="read_velocities">0</param>

--- a/crane_plus_description/urdf/crane_plus.urdf.xacro
+++ b/crane_plus_description/urdf/crane_plus.urdf.xacro
@@ -13,6 +13,7 @@
   <xacro:include filename="$(find crane_plus_description)/urdf/crane_plus.gazebo_ros2_control.xacro"/>
 
   <xacro:arg name="use_gazebo" default="false" />
+  <xacro:arg name="port_name" default="/dev/ttyUSB0" />
 
   <!-- Link to provide the location reference for the arm -->
   <link name="base_link"/>
@@ -100,7 +101,8 @@
       joint_4_lower_limit="${JOINT_4_LOWER_LIMIT}"
       joint_4_upper_limit="${JOINT_4_UPPER_LIMIT}"
       joint_hand_lower_limit="${JOINT_HAND_LOWER_LIMIT}"
-      joint_hand_upper_limit="${JOINT_HAND_UPPER_LIMIT}" />
+      joint_hand_upper_limit="${JOINT_HAND_UPPER_LIMIT}"
+      port_name="$(arg port_name)" />
   </xacro:unless>
 
   <xacro:if value="$(arg use_gazebo)">

--- a/crane_plus_description/urdf/crane_plus.urdf.xacro
+++ b/crane_plus_description/urdf/crane_plus.urdf.xacro
@@ -14,6 +14,12 @@
 
   <xacro:arg name="use_gazebo" default="false" />
   <xacro:arg name="port_name" default="/dev/ttyUSB0" />
+  <xacro:arg name="baudrate" default="1000000" />
+  <xacro:arg name="timeout_seconds" default="5.0" />
+  <xacro:arg name="read_velocities" default="0" />
+  <xacro:arg name="read_loads" default="0" />
+  <xacro:arg name="read_voltages" default="0" />
+  <xacro:arg name="read_temperatures" default="0" />
 
   <!-- Link to provide the location reference for the arm -->
   <link name="base_link"/>
@@ -102,7 +108,13 @@
       joint_4_upper_limit="${JOINT_4_UPPER_LIMIT}"
       joint_hand_lower_limit="${JOINT_HAND_LOWER_LIMIT}"
       joint_hand_upper_limit="${JOINT_HAND_UPPER_LIMIT}"
-      port_name="$(arg port_name)" />
+      port_name="$(arg port_name)"
+      baudrate="$(arg baudrate)"
+      timeout_seconds="$(arg timeout_seconds)"
+      read_velocities="$(arg read_velocities)"
+      read_loads="$(arg read_loads)"
+      read_voltages="$(arg read_voltages)"
+      read_temperatures="$(arg read_temperatures)" />
   </xacro:unless>
 
   <xacro:if value="$(arg use_gazebo)">

--- a/crane_plus_examples/README.md
+++ b/crane_plus_examples/README.md
@@ -27,7 +27,7 @@ USB通信ポートの設定については`crane_plus_control`の
 controller (`crane_plus_control`)を起動します。
 
 ```sh
-$ ros2 launch crane_plus_examples demo.launch.py
+$ ros2 launch crane_plus_examples demo.launch.py port_name:=/dev/ttyUSB0
 ```
 
 ## 準備（Gazeboを使う場合）

--- a/crane_plus_examples/launch/demo.launch.py
+++ b/crane_plus_examples/launch/demo.launch.py
@@ -15,10 +15,17 @@
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 
 def generate_launch_description():
+    declare_port_name = DeclareLaunchArgument(
+        'port_name',
+        default_value='/dev/ttyUSB0',
+        description='Set port name.'
+    )
     move_group = IncludeLaunchDescription(
             PythonLaunchDescriptionSource([
                 get_package_share_directory('crane_plus_moveit_config'),
@@ -29,8 +36,13 @@ def generate_launch_description():
             PythonLaunchDescriptionSource([
                 get_package_share_directory('crane_plus_control'),
                 '/launch/crane_plus_control.launch.py']),
+                launch_arguments={
+                    'port_name': LaunchConfiguration('port_name')
+                }.items(),
         )
 
-    return LaunchDescription([move_group,
-                              control_node
-                              ])
+    return LaunchDescription([
+        declare_port_name,
+        move_group,
+        control_node
+    ])

--- a/crane_plus_examples/launch/demo.launch.py
+++ b/crane_plus_examples/launch/demo.launch.py
@@ -36,9 +36,7 @@ def generate_launch_description():
             PythonLaunchDescriptionSource([
                 get_package_share_directory('crane_plus_control'),
                 '/launch/crane_plus_control.launch.py']),
-                launch_arguments={
-                    'port_name': LaunchConfiguration('port_name')
-                }.items(),
+            launch_arguments={'port_name': LaunchConfiguration('port_name')}.items()
         )
 
     return LaunchDescription([


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
hardware_interfaceのパラメータをxacro引数から変更できるようにしました。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
#34 をクローズします

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
下記コマンドを実行して使用するUSBポートの指定ができることを確認しました。

```
$ ros2 launch crane_plus_examples demo.launch.py port_name:=/dev/ttyUSB0
```

# Any other comments?
<!-- その他コメントはありますか？ -->
ないです

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
