### PR TITLE
crane_plus_ignition起動時のカメラ位置変更

### DIFF
--- a/crane_plus_ignition/CMakeLists.txt
+++ b/crane_plus_ignition/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(ament_cmake REQUIRED)
 install(DIRECTORY
   launch
   worlds
+  gui
   DESTINATION share/${PROJECT_NAME}/
 )
 

--- a/crane_plus_ignition/gui/gui.config
+++ b/crane_plus_ignition/gui/gui.config
@@ -1,0 +1,147 @@
+<?xml version="1.0"?>
+
+<!-- Window -->
+<window>
+  <width>1000</width>
+  <height>845</height>
+  <style
+    material_theme="Light"
+    material_primary="DeepOrange"
+    material_accent="LightBlue"
+    toolbar_color_light="#f3f3f3"
+    toolbar_text_color_light="#111111"
+    toolbar_color_dark="#414141"
+    toolbar_text_color_dark="#f3f3f3"
+    plugin_toolbar_color_light="#bbdefb"
+    plugin_toolbar_text_color_light="#111111"
+    plugin_toolbar_color_dark="#607d8b"
+    plugin_toolbar_text_color_dark="#eeeeee"
+  />
+  <menus>
+    <drawer default="false">
+    </drawer>
+  </menus>
+  <dialog_on_exit>true</dialog_on_exit>
+</window>
+
+<!-- GUI plugins -->
+
+<!-- 3D scene -->
+<plugin filename="GzScene3D" name="3D View">
+  <ignition-gui>
+    <title>3D View</title>
+    <property type="bool" key="showTitleBar">false</property>
+    <property type="string" key="state">docked</property>
+  </ignition-gui>
+
+  <engine>ogre2</engine>
+  <scene>scene</scene>
+  <ambient_light>0.4 0.4 0.4</ambient_light>
+  <background_color>0.8 0.8 0.8</background_color>
+  <camera_pose>0.5 0 1.5 0 0.5 3.14</camera_pose>
+</plugin>
+
+<!-- Play / pause / step -->
+<plugin filename="WorldControl" name="World control">
+  <ignition-gui>
+    <title>World control</title>
+    <property type="bool" key="showTitleBar">false</property>
+    <property type="bool" key="resizable">false</property>
+    <property type="double" key="height">72</property>
+    <property type="double" key="width">121</property>
+    <property type="double" key="z">1</property>
+
+    <property type="string" key="state">floating</property>
+    <anchors target="3D View">
+      <line own="left" target="left"/>
+      <line own="bottom" target="bottom"/>
+    </anchors>
+  </ignition-gui>
+
+  <play_pause>true</play_pause>
+  <step>true</step>
+  <start_paused>true</start_paused>
+
+</plugin>
+
+<!-- Time / RTF -->
+<plugin filename="WorldStats" name="World stats">
+  <ignition-gui>
+    <title>World stats</title>
+    <property type="bool" key="showTitleBar">false</property>
+    <property type="bool" key="resizable">false</property>
+    <property type="double" key="height">110</property>
+    <property type="double" key="width">290</property>
+    <property type="double" key="z">1</property>
+
+    <property type="string" key="state">floating</property>
+    <anchors target="3D View">
+      <line own="right" target="right"/>
+      <line own="bottom" target="bottom"/>
+    </anchors>
+  </ignition-gui>
+
+  <sim_time>true</sim_time>
+  <real_time>true</real_time>
+  <real_time_factor>true</real_time_factor>
+  <iterations>true</iterations>
+
+</plugin>
+
+<!-- Translate / rotate -->
+<plugin filename="TransformControl" name="Transform control">
+  <ignition-gui>
+    <property key="resizable" type="bool">false</property>
+    <property key="x" type="double">0</property>
+    <property key="y" type="double">0</property>
+    <property key="width" type="double">250</property>
+    <property key="height" type="double">50</property>
+    <property key="state" type="string">floating</property>
+    <property key="showTitleBar" type="bool">false</property>
+    <property key="cardBackground" type="string">#666666</property>
+  </ignition-gui>
+</plugin>
+
+<!-- Insert simple shapes -->
+<plugin filename="Shapes" name="Shapes">
+  <ignition-gui>
+    <property key="resizable" type="bool">false</property>
+    <property key="x" type="double">250</property>
+    <property key="y" type="double">0</property>
+    <property key="width" type="double">150</property>
+    <property key="height" type="double">50</property>
+    <property key="state" type="string">floating</property>
+    <property key="showTitleBar" type="bool">false</property>
+    <property key="cardBackground" type="string">#666666</property>
+  </ignition-gui>
+</plugin>
+
+<!-- Screenshot -->
+<plugin filename="Screenshot" name="Screenshot">
+  <ignition-gui>
+    <property key="resizable" type="bool">false</property>
+    <property key="x" type="double">400</property>
+    <property key="y" type="double">0</property>
+    <property key="width" type="double">50</property>
+    <property key="height" type="double">50</property>
+    <property key="state" type="string">floating</property>
+    <property key="showTitleBar" type="bool">false</property>
+    <property key="cardBackground" type="string">#666666</property>
+  </ignition-gui>
+</plugin>
+
+<!-- Inspector -->
+<plugin filename="ComponentInspector" name="Component inspector">
+  <ignition-gui>
+    <property type="bool" key="showTitleBar">false</property>
+    <property type="string" key="state">docked</property>
+  </ignition-gui>
+</plugin>
+
+<!-- Entity tree -->
+<plugin filename="EntityTree" name="Entity tree">
+  <ignition-gui>
+    <property type="bool" key="showTitleBar">false</property>
+    <property type="string" key="state">docked</property>
+  </ignition-gui>
+</plugin>

--- a/crane_plus_ignition/launch/crane_plus_ignition.launch.py
+++ b/crane_plus_ignition/launch/crane_plus_ignition.launch.py
@@ -30,9 +30,11 @@ def generate_launch_description():
                get_package_share_directory('crane_plus_description'))}
     world_file = os.path.join(
         get_package_share_directory('crane_plus_ignition'), 'worlds', 'table.sdf')
+    gui_config = os.path.join(
+        get_package_share_directory('crane_plus_ignition'), 'gui', 'gui.config')
     # -r オプションで起動時にシミュレーションをスタートしないと、コントローラが起動しない
     ign_gazebo = ExecuteProcess(
-            cmd=['ign gazebo -r', world_file],
+            cmd=['ign gazebo -r', world_file, '--gui-config', gui_config],
             output='screen',
             additional_env=env,
             shell=True


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
crane_plus_ignition起動時のカメラ位置をロボットに近づけるためgui.configにカメラ位置を記述しました。worldファイルにカメラ位置を書き込むことも可能ですがカメラ位置以外のGUI設定も上書きされてしまうためデフォルトで使用しているgui.configをコピーして使用しました。

使用したgui.configは`~/.ignition/gazebo/gui.config`にあるものです。

* 参考
    * https://gazebosim.org/api/gazebo/4.3/gui_config.html

* 変更前
    * ![Screenshot from 2022-07-20 17-56-44](https://user-images.githubusercontent.com/15693656/179958411-d4268c37-e317-400c-a0dd-a97c06280fd3.png)
* 変更後
    * ![Screenshot from 2022-07-20 18-41-27](https://user-images.githubusercontent.com/15693656/179958430-7339e8bf-376d-478f-8cd2-1b42fa4c4cfd.png)

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
close #42 

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
下記コマンドでIgnition gazeboを実行し起動時のカメラ位置がロボットに近いことを確認しました。

```
$ ros2 launch crane_plus_ignition crane_plus_ignition.launch.py
```

# Any other comments?
<!-- その他コメントはありますか？ -->
なし

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
