### PR TITLE
Webカメラ搭載モデルに対応

### DIFF
--- a/crane_plus_description/README.md
+++ b/crane_plus_description/README.md
@@ -12,6 +12,12 @@ CRANE+ V2のモデルが表示されるので、xacroファイルのデバッグ
 $ ros2 launch crane_plus_description display.launch.py
 ```
 
+Webカメラ搭載モデルの場合は、下記のコマンドを実行してください。
+
+```sh
+$ ros2 launch crane_plus_description display.launch.py use_camera:=true
+```
+
 ![display.launch.py](https://rt-net.github.io/images/crane-plus/display_launch.png)
 
 ## configure servo angle limits

--- a/crane_plus_description/crane_plus_description/robot_description_loader.py
+++ b/crane_plus_description/crane_plus_description/robot_description_loader.py
@@ -28,6 +28,7 @@ class RobotDescriptionLoader():
         self.port_name = '/dev/ttyUSB0'
         self.use_gazebo = 'false'
         self.use_ignition = 'false'
+        self.use_camera = 'false'
 
     def load(self):
         return Command([
@@ -35,5 +36,6 @@ class RobotDescriptionLoader():
                 self.robot_description_path,
                 ' port_name:=', self.port_name,
                 ' use_gazebo:=', self.use_gazebo,
-                ' use_ignition:=', self.use_ignition
+                ' use_ignition:=', self.use_ignition,
+                ' use_camera:=', self.use_camera
                 ])

--- a/crane_plus_description/launch/display.launch.py
+++ b/crane_plus_description/launch/display.launch.py
@@ -16,11 +16,19 @@
 from ament_index_python.packages import get_package_share_directory
 from crane_plus_description.robot_description_loader import RobotDescriptionLoader
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
+    declare_use_camera = DeclareLaunchArgument(
+            'use_camera',
+            default_value='false',
+            description='Set true to attach the camera model.'
+    )
     description_loader = RobotDescriptionLoader()
+    description_loader.use_camera = LaunchConfiguration('use_camera')
 
     rsp = Node(package='robot_state_publisher',
                executable='robot_state_publisher',
@@ -40,4 +48,9 @@ def generate_launch_description():
                      output='log',
                      arguments=['-d', rviz_config_file])
 
-    return LaunchDescription([rsp, jsp, rviz_node])
+    ld = LaunchDescription()
+    ld.add_action(declare_use_camera)
+    ld.add_action(rsp)
+    ld.add_action(jsp)
+    ld.add_action(rviz_node)
+    return ld

--- a/crane_plus_description/launch/display.launch.py
+++ b/crane_plus_description/launch/display.launch.py
@@ -22,11 +22,13 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
+
     declare_use_camera = DeclareLaunchArgument(
             'use_camera',
             default_value='false',
             description='Set true to attach the camera model.'
     )
+
     description_loader = RobotDescriptionLoader()
     description_loader.use_camera = LaunchConfiguration('use_camera')
 

--- a/crane_plus_description/launch/display.launch.py
+++ b/crane_plus_description/launch/display.launch.py
@@ -22,7 +22,6 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
-
     declare_use_camera = DeclareLaunchArgument(
             'use_camera',
             default_value='false',

--- a/crane_plus_description/test/test_robot_description_loader.py
+++ b/crane_plus_description/test/test_robot_description_loader.py
@@ -59,3 +59,10 @@ def test_use_ignition():
     rdl.use_gazebo = 'true'
     rdl.use_ignition = 'true'
     assert 'ign_ros2_control/IgnitionSystem' in exec_load(rdl)
+
+
+def test_use_camera():
+    # use_cameraが変更されて、xacroにcameraがセットされることを期待
+    rdl = RobotDescriptionLoader()
+    rdl.use_camera = 'true'
+    assert 'camera_link' in exec_load(rdl)

--- a/crane_plus_description/urdf/camera.urdf.xacro
+++ b/crane_plus_description/urdf/camera.urdf.xacro
@@ -12,6 +12,7 @@
         <material name="Black" />
       </visual>
     </link>
+
     <joint name="camera_joint" type="fixed">
       <origin xyz="0.1030 0.1025 0.4600" rpy="0 0 0" />
       <parent link="${parent}" />
@@ -19,6 +20,7 @@
     </joint>
 
     <link name="camera_color_frame" />
+
     <joint name="camera_color_joint" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0" />
       <parent link="camera_link" />
@@ -26,6 +28,7 @@
     </joint>
 
     <link name="camera_color_optical_frame" />
+
     <joint name="camera_color_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="0 ${radians(180)} ${radians(90)}" />
       <parent link="camera_color_frame" />

--- a/crane_plus_description/urdf/camera.urdf.xacro
+++ b/crane_plus_description/urdf/camera.urdf.xacro
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<robot name="camera" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:macro name="sensor_camera" params="parent">
+
+    <link name="camera_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <box size="0.05 0.05 0.05" />
+        </geometry>
+	<material name="Black" />
+      </visual>
+    </link>
+
+    <joint name="camera_joint" type="fixed">
+      <origin xyz="0.1030 0.1025 0.4600" rpy="0 0 0" />
+      <parent link="${parent}" />
+      <child link="camera_link" />
+    </joint>
+
+  </xacro:macro>
+</robot>

--- a/crane_plus_description/urdf/camera.urdf.xacro
+++ b/crane_plus_description/urdf/camera.urdf.xacro
@@ -3,6 +3,8 @@
 
   <xacro:macro name="sensor_camera" params="parent">
 
+    <xacro:property name="M_PI" value="3.1415926535897931" />
+
     <link name="camera_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -12,11 +14,24 @@
 	<material name="Black" />
       </visual>
     </link>
-
     <joint name="camera_joint" type="fixed">
       <origin xyz="0.1030 0.1025 0.4600" rpy="0 0 0" />
       <parent link="${parent}" />
       <child link="camera_link" />
+    </joint>
+
+    <link name="camera_color_frame" />
+    <joint name="camera_color_joint" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="camera_link" />
+      <child link="camera_color_frame" />
+    </joint>
+
+    <link name="camera_color_optical_frame" />
+    <joint name="camera_color_optical_joint" type="fixed">
+      <origin xyz="0 0 0" rpy="0 ${M_PI} ${M_PI/2}" />
+      <parent link="camera_color_frame" />
+      <child link="camera_color_optical_frame" />
     </joint>
 
   </xacro:macro>

--- a/crane_plus_description/urdf/camera.urdf.xacro
+++ b/crane_plus_description/urdf/camera.urdf.xacro
@@ -9,7 +9,7 @@
         <geometry>
           <box size="0.05 0.05 0.05" />
         </geometry>
-  <material name="Black" />
+        <material name="Black" />
       </visual>
     </link>
     <joint name="camera_joint" type="fixed">

--- a/crane_plus_description/urdf/camera.urdf.xacro
+++ b/crane_plus_description/urdf/camera.urdf.xacro
@@ -9,7 +9,7 @@
         <geometry>
           <box size="0.05 0.05 0.05" />
         </geometry>
-	<material name="Black" />
+  <material name="Black" />
       </visual>
     </link>
     <joint name="camera_joint" type="fixed">
@@ -27,7 +27,7 @@
 
     <link name="camera_color_optical_frame" />
     <joint name="camera_color_optical_joint" type="fixed">
-	    <origin xyz="0 0 0" rpy="0 ${radians(180)} ${radians(90)}" />
+      <origin xyz="0 0 0" rpy="0 ${radians(180)} ${radians(90)}" />
       <parent link="camera_color_frame" />
       <child link="camera_color_optical_frame" />
     </joint>

--- a/crane_plus_description/urdf/camera.urdf.xacro
+++ b/crane_plus_description/urdf/camera.urdf.xacro
@@ -3,8 +3,6 @@
 
   <xacro:macro name="sensor_camera" params="parent">
 
-    <xacro:property name="M_PI" value="3.1415926535897931" />
-
     <link name="camera_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -29,7 +27,7 @@
 
     <link name="camera_color_optical_frame" />
     <joint name="camera_color_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="0 ${M_PI} ${M_PI/2}" />
+	    <origin xyz="0 0 0" rpy="0 ${radians(180)} ${radians(90)}" />
       <parent link="camera_color_frame" />
       <child link="camera_color_optical_frame" />
     </joint>

--- a/crane_plus_description/urdf/camera_stand.urdf.xacro
+++ b/crane_plus_description/urdf/camera_stand.urdf.xacro
@@ -1,0 +1,109 @@
+<?xml version="1.0"?>
+<robot name="camera_stand_parts" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:macro name="camera_stand" params="parent">
+
+    <link name="camera_stand_p1">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <box size="0.02 0.02 0.285" />
+        </geometry>
+	<material name="grey">
+	  <color rgba="0.8 0.8 0.8 1.0" />
+        </material>
+      </visual>
+    </link>
+    <joint name="camera_stand_joint1" type="fixed">
+      <origin xyz="-0.05 0.08 0" rpy="${radians(90)} 0 0" />
+      <parent link="${parent}" />
+      <child link="camera_stand_p1" />
+    </joint>
+
+    <link name="camera_stand_p2">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <box size="0.02 0.02 0.44" />
+        </geometry>
+	<material name="grey">
+	  <color rgba="0.8 0.8 0.8 1.0" />
+        </material>
+      </visual>
+    </link>
+    <joint name="camera_stand_joint2" type="fixed">
+      <origin xyz="-0.05 0.1025 0.23" rpy="0 0 0" />
+      <parent link="${parent}" />
+      <child link="camera_stand_p2" />
+    </joint>
+
+    <link name="camera_stand_p3">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <box size="0.02 0.02 0.13" />
+        </geometry>
+	<material name="grey">
+	  <color rgba="0.8 0.8 0.8 1.0" />
+        </material>
+      </visual>
+    </link>
+    <joint name="camera_stand_joint3" type="fixed">
+      <origin xyz="0.02 0.1025 0.44" rpy="0 ${radians(90)} 0" />
+      <parent link="${parent}" />
+      <child link="camera_stand_p3" />
+    </joint>
+
+    <link name="camera_stand_p4">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <box size="0.02 0.02 0.13" />
+        </geometry>
+	<material name="grey">
+	  <color rgba="0.8 0.8 0.8 1.0" />
+        </material>
+      </visual>
+    </link>
+    <joint name="camera_stand_joint4" type="fixed">
+      <origin xyz="0.02 -0.0525 0" rpy="0 ${radians(90)} 0" />
+      <parent link="${parent}" />
+      <child link="camera_stand_p4" />
+    </joint>
+
+    <link name="camera_stand_p5">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <box size="0.02 0.02 0.13" />
+        </geometry>
+	<material name="grey">
+	  <color rgba="0.8 0.8 0.8 1.0" />
+        </material>
+      </visual>
+    </link>
+    <joint name="camera_stand_joint5" type="fixed">
+      <origin xyz="0.02 0.0525 0" rpy="0 ${radians(90)} 0" />
+      <parent link="${parent}" />
+      <child link="camera_stand_p5" />
+    </joint>
+
+    <link name="camera_stand_p6">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <box size="0.02 0.02 0.13" />
+        </geometry>
+	<material name="grey">
+	  <color rgba="0.8 0.8 0.8 1.0" />
+        </material>
+      </visual>
+    </link>
+    <joint name="camera_stand_joint6" type="fixed">
+      <origin xyz="0.02 0.2125 0" rpy="0 ${radians(90)} 0" />
+      <parent link="${parent}" />
+      <child link="camera_stand_p6" />
+    </joint>
+
+  </xacro:macro>
+</robot>

--- a/crane_plus_description/urdf/camera_stand.urdf.xacro
+++ b/crane_plus_description/urdf/camera_stand.urdf.xacro
@@ -14,6 +14,7 @@
         </material>
       </visual>
     </link>
+
     <joint name="camera_stand_joint1" type="fixed">
       <origin xyz="-0.05 0.08 0" rpy="${radians(90)} 0 0" />
       <parent link="${parent}" />
@@ -31,6 +32,7 @@
         </material>
       </visual>
     </link>
+
     <joint name="camera_stand_joint2" type="fixed">
       <origin xyz="-0.05 0.1025 0.23" rpy="0 0 0" />
       <parent link="${parent}" />
@@ -48,6 +50,7 @@
         </material>
       </visual>
     </link>
+
     <joint name="camera_stand_joint3" type="fixed">
       <origin xyz="0.02 0.1025 0.44" rpy="0 ${radians(90)} 0" />
       <parent link="${parent}" />
@@ -65,6 +68,7 @@
         </material>
       </visual>
     </link>
+
     <joint name="camera_stand_joint4" type="fixed">
       <origin xyz="0.02 -0.0525 0" rpy="0 ${radians(90)} 0" />
       <parent link="${parent}" />
@@ -82,6 +86,7 @@
         </material>
       </visual>
     </link>
+
     <joint name="camera_stand_joint5" type="fixed">
       <origin xyz="0.02 0.0525 0" rpy="0 ${radians(90)} 0" />
       <parent link="${parent}" />
@@ -99,6 +104,7 @@
         </material>
       </visual>
     </link>
+
     <joint name="camera_stand_joint6" type="fixed">
       <origin xyz="0.02 0.2125 0" rpy="0 ${radians(90)} 0" />
       <parent link="${parent}" />

--- a/crane_plus_description/urdf/camera_stand.urdf.xacro
+++ b/crane_plus_description/urdf/camera_stand.urdf.xacro
@@ -9,8 +9,8 @@
         <geometry>
           <box size="0.02 0.02 0.285" />
         </geometry>
-	<material name="grey">
-	  <color rgba="0.8 0.8 0.8 1.0" />
+        <material name="grey">
+          <color rgba="0.8 0.8 0.8 1.0" />
         </material>
       </visual>
     </link>
@@ -26,8 +26,8 @@
         <geometry>
           <box size="0.02 0.02 0.44" />
         </geometry>
-	<material name="grey">
-	  <color rgba="0.8 0.8 0.8 1.0" />
+        <material name="grey">
+          <color rgba="0.8 0.8 0.8 1.0" />
         </material>
       </visual>
     </link>
@@ -43,8 +43,8 @@
         <geometry>
           <box size="0.02 0.02 0.13" />
         </geometry>
-	<material name="grey">
-	  <color rgba="0.8 0.8 0.8 1.0" />
+        <material name="grey">
+          <color rgba="0.8 0.8 0.8 1.0" />
         </material>
       </visual>
     </link>
@@ -60,8 +60,8 @@
         <geometry>
           <box size="0.02 0.02 0.13" />
         </geometry>
-	<material name="grey">
-	  <color rgba="0.8 0.8 0.8 1.0" />
+        <material name="grey">
+          <color rgba="0.8 0.8 0.8 1.0" />
         </material>
       </visual>
     </link>
@@ -77,8 +77,8 @@
         <geometry>
           <box size="0.02 0.02 0.13" />
         </geometry>
-	<material name="grey">
-	  <color rgba="0.8 0.8 0.8 1.0" />
+        <material name="grey">
+          <color rgba="0.8 0.8 0.8 1.0" />
         </material>
       </visual>
     </link>
@@ -94,8 +94,8 @@
         <geometry>
           <box size="0.02 0.02 0.13" />
         </geometry>
-	<material name="grey">
-	  <color rgba="0.8 0.8 0.8 1.0" />
+        <material name="grey">
+          <color rgba="0.8 0.8 0.8 1.0" />
         </material>
       </visual>
     </link>

--- a/crane_plus_description/urdf/crane_plus.urdf.xacro
+++ b/crane_plus_description/urdf/crane_plus.urdf.xacro
@@ -14,6 +14,7 @@
 
   <xacro:arg name="use_gazebo" default="false" />
   <xacro:arg name="use_ignition" default="false" />
+  <xacro:arg name="use_camera" default="false" />
   <xacro:arg name="port_name" default="/dev/ttyUSB0" />
   <xacro:arg name="baudrate" default="1000000" />
   <xacro:arg name="timeout_seconds" default="5.0" />
@@ -87,7 +88,8 @@
     joint_4_lower_limit="${JOINT_4_LOWER_LIMIT}"
     joint_4_upper_limit="${JOINT_4_UPPER_LIMIT}"
     joint_hand_lower_limit="${JOINT_HAND_LOWER_LIMIT}"
-    joint_hand_upper_limit="${JOINT_HAND_UPPER_LIMIT}" >
+    joint_hand_upper_limit="${JOINT_HAND_UPPER_LIMIT}"
+    use_camera="$(arg use_camera)">
     <origin xyz="0 0 0"/>
   </xacro:crane_plus>
 

--- a/crane_plus_description/urdf/crane_plus.xacro
+++ b/crane_plus_description/urdf/crane_plus.xacro
@@ -63,6 +63,7 @@
               joint_4_upper_limit
               joint_hand_lower_limit
               joint_hand_upper_limit
+	      use_camera
               *origin">
 
     <joint name="${name_joint_base}" type="fixed">
@@ -296,6 +297,14 @@
         <inertia ixx="5.76E-06" ixy="-4.66E-07" ixz="0.0" iyy="2.76E-05" iyz="0.0" izz="2.52E-05"/>
       </inertial>
     </link>
+
+    <!-- camera -->
+    <xacro:if value="$(arg use_camera)">
+      <xacro:include filename="$(find crane_plus_description)/urdf/camera.urdf.xacro" />
+      <xacro:include filename="$(find crane_plus_description)/urdf/camera_stand.urdf.xacro" />
+      <xacro:sensor_camera parent="${name_link_base}" />
+      <xacro:camera_stand parent="${name_link_base}" />
+    </xacro:if>
 
   </xacro:macro>
 </robot>

--- a/crane_plus_description/urdf/crane_plus.xacro
+++ b/crane_plus_description/urdf/crane_plus.xacro
@@ -63,7 +63,7 @@
               joint_4_upper_limit
               joint_hand_lower_limit
               joint_hand_upper_limit
-	      use_camera
+              use_camera
               *origin">
 
     <joint name="${name_joint_base}" type="fixed">

--- a/crane_plus_examples/README.md
+++ b/crane_plus_examples/README.md
@@ -30,6 +30,12 @@ controller (`crane_plus_control`)を起動します。
 $ ros2 launch crane_plus_examples demo.launch.py port_name:=/dev/ttyUSB0
 ```
 
+Webカメラ搭載モデルの場合は、次のコマンドを実行してください。
+
+```sh
+$ ros2 launch crane_plus_examples demo.launch.py port_name:=/dev/ttyUSB0 use_camera:=true
+```
+
 ## 準備（Ignition Gazeboを使う場合）
 
 ![crane_plus_ignition](https://rt-net.github.io/images/crane-plus/crane_plus_ignition.png)

--- a/crane_plus_examples/README.md
+++ b/crane_plus_examples/README.md
@@ -31,9 +31,10 @@ $ ros2 launch crane_plus_examples demo.launch.py port_name:=/dev/ttyUSB0
 ```
 
 Webカメラ搭載モデルの場合は、次のコマンドを実行してください。
+```video_device```は使用するWebカメラを指定してください。
 
 ```sh
-$ ros2 launch crane_plus_examples demo.launch.py port_name:=/dev/ttyUSB0 use_camera:=true
+$ ros2 launch crane_plus_examples demo.launch.py port_name:=/dev/ttyUSB0 use_camera:=true video_device:=/dev/video0
 ```
 
 ## 準備（Ignition Gazeboを使う場合）

--- a/crane_plus_examples/launch/demo.launch.py
+++ b/crane_plus_examples/launch/demo.launch.py
@@ -15,6 +15,7 @@
 from ament_index_python.packages import get_package_share_directory
 from crane_plus_description.robot_description_loader import RobotDescriptionLoader
 from launch import LaunchDescription
+from launch_ros.actions import Node
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
 from launch.conditions import IfCondition
@@ -54,11 +55,13 @@ def generate_launch_description():
             launch_arguments={'loaded_description': description}.items()
         )
 
-    usb_cam_node = IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([
-                get_package_share_directory('usb_cam'),
-                '/launch/demo_launch.py']),
-            condition=IfCondition(LaunchConfiguration('use_camera')),
+    usb_cam_node = Node(
+            package='usb_cam',
+            executable='usb_cam_node_exe',
+            parameters=[
+                {'video_device': '/dev/video2'},
+                {'frame_id': 'camera_color_optical_frame'}
+            ]
         )
 
     return LaunchDescription([

--- a/crane_plus_examples/launch/demo.launch.py
+++ b/crane_plus_examples/launch/demo.launch.py
@@ -24,6 +24,7 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
+
     declare_port_name = DeclareLaunchArgument(
         'port_name',
         default_value='/dev/ttyUSB0',
@@ -45,7 +46,6 @@ def generate_launch_description():
     description_loader = RobotDescriptionLoader()
     description_loader.port_name = LaunchConfiguration('port_name')
     description_loader.use_camera = LaunchConfiguration('use_camera')
-    description_loader.video_device = LaunchConfiguration('video_device')
     description = description_loader.load()
 
     move_group = IncludeLaunchDescription(
@@ -66,7 +66,7 @@ def generate_launch_description():
             package='usb_cam',
             executable='usb_cam_node_exe',
             parameters=[
-                {'video_device': description_loader.video_device},
+                {'video_device': LaunchConfiguration('video_device')},
                 {'frame_id': 'camera_color_optical_frame'}
             ],
             condition=IfCondition(LaunchConfiguration('use_camera'))

--- a/crane_plus_examples/launch/demo.launch.py
+++ b/crane_plus_examples/launch/demo.launch.py
@@ -15,12 +15,12 @@
 from ament_index_python.packages import get_package_share_directory
 from crane_plus_description.robot_description_loader import RobotDescriptionLoader
 from launch import LaunchDescription
-from launch_ros.actions import Node
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
 
 
 def generate_launch_description():
@@ -61,7 +61,8 @@ def generate_launch_description():
             parameters=[
                 {'video_device': '/dev/video2'},
                 {'frame_id': 'camera_color_optical_frame'}
-            ]
+            ],
+            condition=IfCondition(LaunchConfiguration('use_camera'))
         )
 
     return LaunchDescription([

--- a/crane_plus_examples/launch/demo.launch.py
+++ b/crane_plus_examples/launch/demo.launch.py
@@ -17,6 +17,7 @@ from crane_plus_description.robot_description_loader import RobotDescriptionLoad
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
@@ -53,9 +54,17 @@ def generate_launch_description():
             launch_arguments={'loaded_description': description}.items()
         )
 
+    usb_cam_node = IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([
+                get_package_share_directory('usb_cam'),
+                '/launch/demo_launch.py']),
+            condition=IfCondition(LaunchConfiguration('use_camera')),
+        )
+
     return LaunchDescription([
         declare_port_name,
         declare_use_camera,
         move_group,
-        control_node
+        control_node,
+        usb_cam_node
     ])

--- a/crane_plus_examples/launch/demo.launch.py
+++ b/crane_plus_examples/launch/demo.launch.py
@@ -36,9 +36,16 @@ def generate_launch_description():
         description='Use camera.'
     )
 
+    declare_video_device = DeclareLaunchArgument(
+        'video_device',
+        default_value='/dev/video0',
+        description='Set video device.'
+    )
+
     description_loader = RobotDescriptionLoader()
     description_loader.port_name = LaunchConfiguration('port_name')
     description_loader.use_camera = LaunchConfiguration('use_camera')
+    description_loader.video_device = LaunchConfiguration('video_device')
     description = description_loader.load()
 
     move_group = IncludeLaunchDescription(
@@ -59,7 +66,7 @@ def generate_launch_description():
             package='usb_cam',
             executable='usb_cam_node_exe',
             parameters=[
-                {'video_device': '/dev/video2'},
+                {'video_device': description_loader.video_device},
                 {'frame_id': 'camera_color_optical_frame'}
             ],
             condition=IfCondition(LaunchConfiguration('use_camera'))
@@ -68,6 +75,7 @@ def generate_launch_description():
     return LaunchDescription([
         declare_port_name,
         declare_use_camera,
+        declare_video_device,
         move_group,
         control_node,
         usb_cam_node

--- a/crane_plus_examples/launch/demo.launch.py
+++ b/crane_plus_examples/launch/demo.launch.py
@@ -24,7 +24,6 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
-
     declare_port_name = DeclareLaunchArgument(
         'port_name',
         default_value='/dev/ttyUSB0',

--- a/crane_plus_examples/launch/demo.launch.py
+++ b/crane_plus_examples/launch/demo.launch.py
@@ -28,8 +28,15 @@ def generate_launch_description():
         description='Set port name.'
     )
 
+    declare_use_camera = DeclareLaunchArgument(
+        'use_camera',
+        default_value='false',
+        description='Use camera.'
+    )
+
     description_loader = RobotDescriptionLoader()
     description_loader.port_name = LaunchConfiguration('port_name')
+    description_loader.use_camera = LaunchConfiguration('use_camera')
     description = description_loader.load()
 
     move_group = IncludeLaunchDescription(
@@ -48,6 +55,7 @@ def generate_launch_description():
 
     return LaunchDescription([
         declare_port_name,
+        declare_use_camera,
         move_group,
         control_node
     ])

--- a/crane_plus_examples/package.xml
+++ b/crane_plus_examples/package.xml
@@ -19,6 +19,7 @@
   <depend>moveit_ros_planning_interface</depend>
   <depend>rclcpp</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>usb_cam</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
Webカメラとカメラの台のxacroファイルを新たに作成しました。
launch実行時に```use_camera:=true```を追加することで、標準モデルとWebカメラ搭載モデルを切り替えることが可能です。
URDFの切り替え方法に関しては、CRANE X7の方法を参考にいたしました（https://github.com/rt-net/crane_x7_description/pull/5）。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
以下の2つのコマンドで、Webカメラ搭載モデルがRViz上に表示されることを確認いたしました。

```
ros2 launch crane_plus_description display.launch.py use_camera:=true
ros2 launch crane_plus_examples demo.launch.py port_name:=/dev/ttyUSB0 use_camera:=true
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
