### PR TITLE
gz_ros2_control 0.1.5対応

### DIFF
--- a/crane_plus_examples/README.md
+++ b/crane_plus_examples/README.md
@@ -54,6 +54,14 @@ $ ros2 launch crane_plus_examples example.launch.py example:='gripper_control'
 
 終了するときは`Ctrl+c`を入力します。
 
+### Gazeboでサンプルプログラムを実行する場合
+
+Gazeboでサンプルプログラムを実行する場合は`use_sim_time`オプションを付けます。
+
+```sh
+ros2 launch crane_plus_examples example.launch.py example:='gripper_control' use_sim_time:='true'
+```
+
 ## Examples
 
 `demo.launch.py`を実行している状態で各サンプルを実行できます。

--- a/crane_plus_examples/launch/example.launch.py
+++ b/crane_plus_examples/launch/example.launch.py
@@ -20,6 +20,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch_ros.actions import SetParameter
 import yaml
 
 
@@ -61,6 +62,11 @@ def generate_launch_description():
                      '[gripper_control, pose_groupstate, joint_values, pick_and_place]')
     )
 
+    declare_use_sim_time = DeclareLaunchArgument(
+        'use_sim_time', default_value='false',
+        description=('Set true when using the gazebo simulator.')
+    )
+
     example_node = Node(name=[LaunchConfiguration('example'), '_node'],
                         package='crane_plus_examples',
                         executable=LaunchConfiguration('example'),
@@ -69,4 +75,9 @@ def generate_launch_description():
                                     robot_description_semantic,
                                     kinematics_yaml])
 
-    return LaunchDescription([declare_example_name, example_node])
+    return LaunchDescription([
+        declare_use_sim_time,
+        SetParameter(name='use_sim_time', value=LaunchConfiguration('use_sim_time')),
+        declare_example_name,
+        example_node
+    ])

--- a/crane_plus_ignition/launch/crane_plus_ignition.launch.py
+++ b/crane_plus_ignition/launch/crane_plus_ignition.launch.py
@@ -21,6 +21,7 @@ from launch.actions import ExecuteProcess
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
+from launch_ros.actions import SetParameter
 
 
 def generate_launch_description():
@@ -80,11 +81,20 @@ def generate_launch_description():
                 output='screen',
             )
 
+    bridge = Node(
+                package='ros_ign_bridge',
+                executable='parameter_bridge',
+                arguments=['/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock'],
+                output='screen'
+            )
+
     return LaunchDescription([
+        SetParameter(name='use_sim_time', value=True),
         ign_gazebo,
         move_group,
         ignition_spawn_entity,
         spawn_joint_state_controller,
         spawn_arm_controller,
-        spawn_gripper_controller
+        spawn_gripper_controller,
+        bridge
     ])


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
gz_ros2_control 0.1.5からuse_sim_timeを有効にする必要があったためuse_sim_time、parameter_bridgeを追加しました。
関連PR: https://github.com/ros-controls/gz_ros2_control/pull/100

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
下記コマンドでシミュレータを起動し、RVizからマニピュレータの操作ができることを確認しました。
```
ros2 launch crane_plus_ignition crane_plus_ignition.launch.py
```

# Any other comments?
<!-- その他コメントはありますか？ -->
clockの同期はシミュレータのclockをその他のノードに同期させるためparameter_bridgeの引数は以下のように記述する必要があります。
```
'/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock'
```
関連issue: https://github.com/gazebosim/ros_gz/issues/341

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
