### PR TITLE
軌道生成の失敗時にpick_and_placeを中断する機能を追加

### DIFF
--- a/crane_plus_examples/src/pick_and_place_tf.cpp
+++ b/crane_plus_examples/src/pick_and_place_tf.cpp
@@ -155,7 +155,12 @@ private:
     const double GRIPPER_OFFSET = 0.13;
     double gripper_offset_x = GRIPPER_OFFSET * std::cos(theta_rad);
     double gripper_offset_y = GRIPPER_OFFSET * std::sin(theta_rad);
-    control_arm(x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90, theta_deg);
+    if(control_arm(x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90, theta_deg) != 1)
+    {
+      // 軌道生成に失敗した時はpick_and_placeを中断して待機姿勢に戻る
+      control_arm(0.0, 0.0, 0.17, 0, 0, 0);
+      return;
+    }
 
     // ハンドを閉じる
     control_gripper(GRIPPER_CLOSE);
@@ -189,7 +194,7 @@ private:
   }
 
   // アーム制御
-  void control_arm(
+  int control_arm(
     const double x, const double y, const double z,
     const double roll, const double pitch, const double yaw)
   {
@@ -201,7 +206,8 @@ private:
     q.setRPY(angles::from_degrees(roll), angles::from_degrees(pitch), angles::from_degrees(yaw));
     target_pose.orientation = tf2::toMsg(q);
     move_group_arm_->setPoseTarget(target_pose);
-    move_group_arm_->move();
+    moveit::core::MoveItErrorCode result = move_group_arm_->move();
+    return result.val;
   }
 
   std::shared_ptr<MoveGroupInterface> move_group_arm_;

--- a/crane_plus_examples/src/pick_and_place_tf.cpp
+++ b/crane_plus_examples/src/pick_and_place_tf.cpp
@@ -155,10 +155,7 @@ private:
     const double GRIPPER_OFFSET = 0.13;
     double gripper_offset_x = GRIPPER_OFFSET * std::cos(theta_rad);
     double gripper_offset_y = GRIPPER_OFFSET * std::sin(theta_rad);
-    if (control_arm(
-        x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90,
-        theta_deg) != moveit::core::MoveItErrorCode::SUCCESS)
-    {
+    if (!control_arm(x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90, theta_deg)) {
       // アーム動作に失敗した時はpick_and_placeを中断して待機姿勢に戻る
       control_arm(0.0, 0.0, 0.17, 0, 0, 0);
       return;
@@ -196,7 +193,7 @@ private:
   }
 
   // アーム制御
-  int control_arm(
+  bool control_arm(
     const double x, const double y, const double z,
     const double roll, const double pitch, const double yaw)
   {
@@ -208,8 +205,13 @@ private:
     q.setRPY(angles::from_degrees(roll), angles::from_degrees(pitch), angles::from_degrees(yaw));
     target_pose.orientation = tf2::toMsg(q);
     move_group_arm_->setPoseTarget(target_pose);
+    // アーム動作の成否を取得
     moveit::core::MoveItErrorCode result = move_group_arm_->move();
-    return result.val;
+    if (result.val == moveit::core::MoveItErrorCode::SUCCESS) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   std::shared_ptr<MoveGroupInterface> move_group_arm_;

--- a/crane_plus_examples/src/pick_and_place_tf.cpp
+++ b/crane_plus_examples/src/pick_and_place_tf.cpp
@@ -155,8 +155,7 @@ private:
     const double GRIPPER_OFFSET = 0.13;
     double gripper_offset_x = GRIPPER_OFFSET * std::cos(theta_rad);
     double gripper_offset_y = GRIPPER_OFFSET * std::sin(theta_rad);
-    if(control_arm(x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90, theta_deg) != 1)
-    {
+    if(control_arm(x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90, theta_deg) != 1) {
       // 軌道生成に失敗した時はpick_and_placeを中断して待機姿勢に戻る
       control_arm(0.0, 0.0, 0.17, 0, 0, 0);
       return;

--- a/crane_plus_examples/src/pick_and_place_tf.cpp
+++ b/crane_plus_examples/src/pick_and_place_tf.cpp
@@ -159,7 +159,7 @@ private:
         x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90,
         theta_deg) != moveit::core::MoveItErrorCode::SUCCESS)
     {
-      // 軌道生成に失敗した時はpick_and_placeを中断して待機姿勢に戻る
+      // アーム動作に失敗した時はpick_and_placeを中断して待機姿勢に戻る
       control_arm(0.0, 0.0, 0.17, 0, 0, 0);
       return;
     }

--- a/crane_plus_examples/src/pick_and_place_tf.cpp
+++ b/crane_plus_examples/src/pick_and_place_tf.cpp
@@ -155,7 +155,8 @@ private:
     const double GRIPPER_OFFSET = 0.13;
     double gripper_offset_x = GRIPPER_OFFSET * std::cos(theta_rad);
     double gripper_offset_y = GRIPPER_OFFSET * std::sin(theta_rad);
-    if(control_arm(x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90,
+    if(control_arm(
+       x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90,
        theta_deg) != moveit::core::MoveItErrorCode::SUCCESS)
     {
       // 軌道生成に失敗した時はpick_and_placeを中断して待機姿勢に戻る

--- a/crane_plus_examples/src/pick_and_place_tf.cpp
+++ b/crane_plus_examples/src/pick_and_place_tf.cpp
@@ -207,11 +207,7 @@ private:
     move_group_arm_->setPoseTarget(target_pose);
     // アーム動作の成否を取得
     moveit::core::MoveItErrorCode result = move_group_arm_->move();
-    if (result.val == moveit::core::MoveItErrorCode::SUCCESS) {
-      return true;
-    } else {
-      return false;
-    }
+    return result.val == moveit::core::MoveItErrorCode::SUCCESS;
   }
 
   std::shared_ptr<MoveGroupInterface> move_group_arm_;

--- a/crane_plus_examples/src/pick_and_place_tf.cpp
+++ b/crane_plus_examples/src/pick_and_place_tf.cpp
@@ -155,7 +155,7 @@ private:
     const double GRIPPER_OFFSET = 0.13;
     double gripper_offset_x = GRIPPER_OFFSET * std::cos(theta_rad);
     double gripper_offset_y = GRIPPER_OFFSET * std::sin(theta_rad);
-    if(control_arm(x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90, theta_deg) != 1) {
+    if(control_arm(x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90, theta_deg) != moveit::core::MoveItErrorCode::SUCCESS) {
       // 軌道生成に失敗した時はpick_and_placeを中断して待機姿勢に戻る
       control_arm(0.0, 0.0, 0.17, 0, 0, 0);
       return;

--- a/crane_plus_examples/src/pick_and_place_tf.cpp
+++ b/crane_plus_examples/src/pick_and_place_tf.cpp
@@ -155,7 +155,9 @@ private:
     const double GRIPPER_OFFSET = 0.13;
     double gripper_offset_x = GRIPPER_OFFSET * std::cos(theta_rad);
     double gripper_offset_y = GRIPPER_OFFSET * std::sin(theta_rad);
-    if(control_arm(x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90, theta_deg) != moveit::core::MoveItErrorCode::SUCCESS) {
+    if(control_arm(x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90,
+       theta_deg) != moveit::core::MoveItErrorCode::SUCCESS)
+    {
       // 軌道生成に失敗した時はpick_and_placeを中断して待機姿勢に戻る
       control_arm(0.0, 0.0, 0.17, 0, 0, 0);
       return;

--- a/crane_plus_examples/src/pick_and_place_tf.cpp
+++ b/crane_plus_examples/src/pick_and_place_tf.cpp
@@ -155,9 +155,9 @@ private:
     const double GRIPPER_OFFSET = 0.13;
     double gripper_offset_x = GRIPPER_OFFSET * std::cos(theta_rad);
     double gripper_offset_y = GRIPPER_OFFSET * std::sin(theta_rad);
-    if(control_arm(
-       x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90,
-       theta_deg) != moveit::core::MoveItErrorCode::SUCCESS)
+    if (control_arm(
+        x - gripper_offset_x, y - gripper_offset_y, 0.05, 0, 90,
+        theta_deg) != moveit::core::MoveItErrorCode::SUCCESS)
     {
       // 軌道生成に失敗した時はpick_and_placeを中断して待機姿勢に戻る
       control_arm(0.0, 0.0, 0.17, 0, 0, 0);


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
軌道生成に失敗した時、pick_and_placeを中断して待機姿勢に戻る機能を追加します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
実機のCRANE+ V2で動作確認しました。

実行したコマンドは下記のとおりです。
```sh
# ターミナル1
ros2 launch crane_plus_examples demo.launch.py port_name:=/dev/ttyUSB0 use_camera:=true video_device:=/dev/video2
# ターミナル2
ros2 launch crane_plus_examples camera_example.launch.py example:='color_detection'
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
