### PR TITLE
軌道生成の失敗時にpick_and_placeを中断する機能を追加（Foxy）

### DIFF
--- a/crane_plus_examples/src/pick_and_place_tf.cpp
+++ b/crane_plus_examples/src/pick_and_place_tf.cpp
@@ -206,8 +206,8 @@ private:
     target_pose.orientation = tf2::toMsg(q);
     move_group_arm_->setPoseTarget(target_pose);
     // アーム動作の成否を取得
-    moveit::core::MoveItErrorCode result = move_group_arm_->move();
-    return result.val == moveit::core::MoveItErrorCode::SUCCESS;
+    moveit::planning_interface::MoveItErrorCode result = move_group_arm_->move();
+    return result.val == moveit::planning_interface::MoveItErrorCode::SUCCESS;
   }
 
   std::shared_ptr<MoveGroupInterface> move_group_arm_;


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
軌道生成に失敗した時、pick_and_placeを中断して待機姿勢に戻る機能を追加します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
実機のCRANE+ V2で動作確認しました。

実行したコマンドは下記のとおりです。
```sh
# ターミナル1
ros2 launch crane_plus_examples demo.launch.py port_name:=/dev/ttyUSB0 use_camera:=true video_device:=/dev/video2
# ターミナル2
ros2 launch crane_plus_examples camera_example.launch.py example:='aruco_detection'
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
