### PR TITLE
gui.configをFoxy版のものに置き換える

### DIFF
--- a/crane_plus_gazebo/gui/gui.config
+++ b/crane_plus_gazebo/gui/gui.config
@@ -38,7 +38,7 @@
   <scene>scene</scene>
   <ambient_light>0.4 0.4 0.4</ambient_light>
   <background_color>0.8 0.8 0.8</background_color>
-  <camera_pose>0.5 0 1.5 0 0.5 3.14</camera_pose>
+  <camera_pose>0.4 0 1.4 0 0.4 3.14</camera_pose>
 </plugin>
 
 <!-- Play / pause / step -->

--- a/crane_plus_gazebo/gui/gui.config
+++ b/crane_plus_gazebo/gui/gui.config
@@ -27,7 +27,7 @@
 <!-- GUI plugins -->
 
 <!-- 3D scene -->
-<plugin filename="MinimalScene" name="3D View">
+<plugin filename="GzScene3D" name="3D View">
   <ignition-gui>
     <title>3D View</title>
     <property type="bool" key="showTitleBar">false</property>
@@ -38,85 +38,10 @@
   <scene>scene</scene>
   <ambient_light>0.4 0.4 0.4</ambient_light>
   <background_color>0.8 0.8 0.8</background_color>
-  <camera_pose>1.0 0 2.0 0 0.5 3.14</camera_pose>
+  <camera_pose>0.5 0 1.5 0 0.5 3.14</camera_pose>
 </plugin>
 
-<!-- Plugins that add functionality to the scene -->
-<plugin filename="EntityContextMenuPlugin" name="Entity context menu">
-  <ignition-gui>
-    <property key="state" type="string">floating</property>
-    <property key="width" type="double">5</property>
-    <property key="height" type="double">5</property>
-    <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
-</plugin>
-<plugin filename="GzSceneManager" name="Scene Manager">
-  <ignition-gui>
-    <property key="resizable" type="bool">false</property>
-    <property key="width" type="double">5</property>
-    <property key="height" type="double">5</property>
-    <property key="state" type="string">floating</property>
-    <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
-</plugin>
-<plugin filename="InteractiveViewControl" name="Interactive view control">
-  <ignition-gui>
-    <property key="resizable" type="bool">false</property>
-    <property key="width" type="double">5</property>
-    <property key="height" type="double">5</property>
-    <property key="state" type="string">floating</property>
-    <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
-</plugin>
-<plugin filename="CameraTracking" name="Camera Tracking">
-  <ignition-gui>
-    <property key="resizable" type="bool">false</property>
-    <property key="width" type="double">5</property>
-    <property key="height" type="double">5</property>
-    <property key="state" type="string">floating</property>
-    <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
-</plugin>
-<plugin filename="MarkerManager" name="Marker manager">
-  <ignition-gui>
-    <property key="resizable" type="bool">false</property>
-    <property key="width" type="double">5</property>
-    <property key="height" type="double">5</property>
-    <property key="state" type="string">floating</property>
-    <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
-</plugin>
-<plugin filename="SelectEntities" name="Select Entities">
-  <ignition-gui>
-    <property key="resizable" type="bool">false</property>
-    <property key="width" type="double">5</property>
-    <property key="height" type="double">5</property>
-    <property key="state" type="string">floating</property>
-    <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
-</plugin>
-
-<plugin filename="Spawn" name="Spawn Entities">
-  <ignition-gui>
-    <property key="resizable" type="bool">false</property>
-    <property key="width" type="double">5</property>
-    <property key="height" type="double">5</property>
-    <property key="state" type="string">floating</property>
-    <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
-</plugin>
-
-<plugin filename="VisualizationCapabilities" name="Visualization Capabilities">
-  <ignition-gui>
-    <property key="resizable" type="bool">false</property>
-    <property key="width" type="double">5</property>
-    <property key="height" type="double">5</property>
-    <property key="state" type="string">floating</property>
-    <property key="showTitleBar" type="bool">false</property>
-  </ignition-gui>
-</plugin>
-
-<!-- World control -->
+<!-- Play / pause / step -->
 <plugin filename="WorldControl" name="World control">
   <ignition-gui>
     <title>World control</title>
@@ -136,11 +61,10 @@
   <play_pause>true</play_pause>
   <step>true</step>
   <start_paused>true</start_paused>
-  <use_event>true</use_event>
 
 </plugin>
 
-<!-- World statistics -->
+<!-- Time / RTF -->
 <plugin filename="WorldStats" name="World stats">
   <ignition-gui>
     <title>World stats</title>
@@ -161,10 +85,11 @@
   <real_time>true</real_time>
   <real_time_factor>true</real_time_factor>
   <iterations>true</iterations>
+
 </plugin>
 
-<!-- Insert simple shapes -->
-<plugin filename="Shapes" name="Shapes">
+<!-- Translate / rotate -->
+<plugin filename="TransformControl" name="Transform control">
   <ignition-gui>
     <property key="resizable" type="bool">false</property>
     <property key="x" type="double">0</property>
@@ -177,8 +102,8 @@
   </ignition-gui>
 </plugin>
 
-<!-- Insert lights -->
-<plugin filename="Lights" name="Lights">
+<!-- Insert simple shapes -->
+<plugin filename="Shapes" name="Shapes">
   <ignition-gui>
     <property key="resizable" type="bool">false</property>
     <property key="x" type="double">250</property>
@@ -191,48 +116,17 @@
   </ignition-gui>
 </plugin>
 
-<!-- Translate / rotate -->
-<plugin filename="TransformControl" name="Transform control">
-  <ignition-gui>
-    <property key="resizable" type="bool">false</property>
-    <property key="x" type="double">0</property>
-    <property key="y" type="double">50</property>
-    <property key="width" type="double">250</property>
-    <property key="height" type="double">50</property>
-    <property key="state" type="string">floating</property>
-    <property key="showTitleBar" type="bool">false</property>
-    <property key="cardBackground" type="string">#777777</property>
-  </ignition-gui>
-
-  <!-- disable legacy features used to connect this plugin to GzScene3D -->
-  <legacy>false</legacy>
-</plugin>
-
 <!-- Screenshot -->
 <plugin filename="Screenshot" name="Screenshot">
   <ignition-gui>
     <property key="resizable" type="bool">false</property>
-    <property key="x" type="double">250</property>
-    <property key="y" type="double">50</property>
+    <property key="x" type="double">400</property>
+    <property key="y" type="double">0</property>
     <property key="width" type="double">50</property>
     <property key="height" type="double">50</property>
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>
-    <property key="cardBackground" type="string">#777777</property>
-  </ignition-gui>
-</plugin>
-
-<!-- Copy/Paste -->
-<plugin filename="CopyPaste" name="CopyPaste">
-  <ignition-gui>
-    <property key="resizable" type="bool">false</property>
-    <property key="x" type="double">300</property>
-    <property key="y" type="double">50</property>
-    <property key="width" type="double">100</property>
-    <property key="height" type="double">50</property>
-    <property key="state" type="string">floating</property>
-    <property key="showTitleBar" type="bool">false</property>
-    <property key="cardBackground" type="string">#777777</property>
+    <property key="cardBackground" type="string">#666666</property>
   </ignition-gui>
 </plugin>
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
gui.configをCRANE+ V2のFoxy版のものに置き換えます。
（Humble対応時にCRANE-X7のgui.configに置き換えていたため）

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
Humble環境のGazeboで動作確認しました。

下記のコマンドを実行してテストしました。
```sh
# ターミナル1
ros2 launch crane_plus_gazebo crane_plus_with_table.launch.py
# ターミナル2
ros2 launch crane_plus_examples example.launch.py example:='pick_and_place' use_sim_time:=true
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
