### PR TITLE
launchにchoice設定をする

### DIFF
--- a/crane_plus_description/launch/display.launch.py
+++ b/crane_plus_description/launch/display.launch.py
@@ -25,6 +25,7 @@ def generate_launch_description():
     declare_use_camera = DeclareLaunchArgument(
         'use_camera',
         default_value='false',
+        choices=['true', 'false'],
         description='Set true to attach the camera model.',
     )
 

--- a/crane_plus_examples/launch/camera_example.launch.py
+++ b/crane_plus_examples/launch/camera_example.launch.py
@@ -23,18 +23,23 @@ from moveit_configs_utils import MoveItConfigsBuilder
 
 def generate_launch_description():
     declare_use_camera = DeclareLaunchArgument(
-        'use_camera', default_value='true', description='Use camera.'
+        'use_camera',
+        default_value='true',
+        choices=['true', 'false'],
+        description='Use camera.',
     )
 
     declare_example_name = DeclareLaunchArgument(
         'example',
         default_value='color_detection',
-        description=('Set an example executable name: [color_detection]'),
+        choices=['aruco_detection', 'color_detection'],
+        description='Set an example executable name.',
     )
 
     declare_use_sim_time = DeclareLaunchArgument(
         'use_sim_time',
         default_value='false',
+        choices=['true', 'false'],
         description=('Set true when using the gazebo simulator.'),
     )
 

--- a/crane_plus_examples/launch/demo.launch.py
+++ b/crane_plus_examples/launch/demo.launch.py
@@ -30,7 +30,10 @@ def generate_launch_description():
     )
 
     declare_use_camera = DeclareLaunchArgument(
-        'use_camera', default_value='false', description='Use camera.'
+        'use_camera',
+        default_value='false',
+        choices=['true', 'false'],
+        description='Use camera.',
     )
 
     declare_video_device = DeclareLaunchArgument(
@@ -42,6 +45,7 @@ def generate_launch_description():
     declare_use_mock_components = DeclareLaunchArgument(
         'use_mock_components',
         default_value='false',
+        choices=['true', 'false'],
         description='Use mock_components or not.',
     )
 

--- a/crane_plus_examples/launch/example.launch.py
+++ b/crane_plus_examples/launch/example.launch.py
@@ -23,21 +23,23 @@ from moveit_configs_utils import MoveItConfigsBuilder
 
 def generate_launch_description():
     declare_use_camera = DeclareLaunchArgument(
-        'use_camera', default_value='false', description='Use camera.'
+        'use_camera',
+        default_value='false',
+        choices=['true', 'false'],
+        description='Use camera.',
     )
 
     declare_example_name = DeclareLaunchArgument(
         'example',
         default_value='gripper_control',
-        description=(
-            'Set an example executable name: '
-            '[gripper_control, pose_groupstate, joint_values, pick_and_place]'
-        ),
+        choices=['gripper_control', 'pose_groupstate', 'joint_values', 'pick_and_place'],
+        description='Set an example executable name.',
     )
 
     declare_use_sim_time = DeclareLaunchArgument(
         'use_sim_time',
         default_value='false',
+        choices=['true', 'false'],
         description=('Set true when using the gazebo simulator.'),
     )
 

--- a/crane_plus_examples_py/launch/camera_example.launch.py
+++ b/crane_plus_examples_py/launch/camera_example.launch.py
@@ -50,14 +50,16 @@ def generate_launch_description():
     }
 
     declare_example_name = DeclareLaunchArgument(
-        'example', default_value='color_detection',
-        description=('Set an example executable name: '
-                     '[aruco_detection, color_detection]')
+        'example',
+        default_value='color_detection',
+        choices=['aruco_detection', 'color_detection'],
+        description='Set an example executable name.',
     )
 
     declare_use_sim_time = DeclareLaunchArgument(
         'use_sim_time',
         default_value='false',
+        choices=['true', 'false'],
         description=('Set true when using the gazebo simulator.'),
     )
 

--- a/crane_plus_examples_py/launch/example.launch.py
+++ b/crane_plus_examples_py/launch/example.launch.py
@@ -52,14 +52,14 @@ def generate_launch_description():
     declare_example_name = DeclareLaunchArgument(
         'example',
         default_value='gripper_control',
-        description='Set an example executable name: \
-                    [gripper_control, pose_groupstate, \
-                    joint_values, pick_and_place]'
+        choices=['gripper_control', 'pose_groupstate', 'joint_values', 'pick_and_place'],
+        description='Set an example executable name.',
     )
 
     declare_use_sim_time = DeclareLaunchArgument(
         'use_sim_time',
         default_value='false',
+        choices=['true', 'false'],
         description=('Set true when using the gazebo simulator.'),
     )
 

--- a/crane_plus_gazebo/launch/crane_plus_with_table.launch.py
+++ b/crane_plus_gazebo/launch/crane_plus_with_table.launch.py
@@ -30,7 +30,10 @@ from launch_ros.actions import SetParameter
 
 def generate_launch_description():
     declare_use_camera = DeclareLaunchArgument(
-        'use_camera', default_value='false', description='Use camera.'
+        'use_camera',
+        default_value='false',
+        choices=['true', 'false'],
+        description='Use camera.',
     )
 
     declare_rviz_config = DeclareLaunchArgument(


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

DeclareLaunchArgument に choices を追加し、example や use_gazebo 等の引数に不正な値が渡された際にros2 launch側でバリデーションされるようにした
choices で選択肢を明示できるようになったため、description に手書きしていた選択肢の列挙を削除し簡潔にした

https://github.com/rt-net/crane_x7_ros/pull/218 の CRANE PlusV2版

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->


# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
- 各launchファイルを ros2 launch で実行し、デフォルト値で問題なく起動することを確認
- 存在しない値（例: example:=invalid_name）を指定した際にエラーになることを確認


# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [ ] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [ ] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
